### PR TITLE
feat: adiciona menu de outras cidades

### DIFF
--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,3 +5,4 @@ menu:
 
   - {name: 'Eventos', url: '/events'}
   - {name: 'Meetup', url: 'https://www.meetup.com/porto-alegre-bitdevs', external: true}
+  - {name: 'Outras Cidades', url: '/cities'}

--- a/_data/settings.yml
+++ b/_data/settings.yml
@@ -5,4 +5,4 @@ menu:
 
   - {name: 'Eventos', url: '/events'}
   - {name: 'Meetup', url: 'https://www.meetup.com/porto-alegre-bitdevs', external: true}
-  - {name: 'Outras Cidades', url: '/cities'}
+  - {name: 'Cidades', url: '/cities'}

--- a/assets/css/_header.scss
+++ b/assets/css/_header.scss
@@ -22,6 +22,10 @@
     }
   }
 
+  &-logo-text {
+    white-space: nowrap;
+  }
+
   &-nav {
     display: flex;
     font-size: 1.3rem;
@@ -34,6 +38,7 @@
       color: #333;
       opacity: 0.4;
       margin-left: 1.5rem;
+      white-space: nowrap;
 
       &:hover {
         color: $primary-color;

--- a/cities.md
+++ b/cities.md
@@ -1,6 +1,7 @@
 ---
 layout: default
-title: Outras Cidades
+title: Cidades
+permalink: /cities/
 ---
 <div class="Home">
     <p class="Home-about">

--- a/cities.md
+++ b/cities.md
@@ -15,6 +15,7 @@ title: Outras Cidades
             <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
             <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
             <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+            <li><a href="https://udibitdevs.org/" target="_blank" rel="noopener nofollow">Uberlândia</a></li>
         </ul>
     </div>
 

--- a/cities.md
+++ b/cities.md
@@ -1,0 +1,29 @@
+---
+layout: default
+title: Outras Cidades
+---
+<div class="Home">
+    <p class="Home-about">
+        O formato BitDevs se espalhou por várias cidades do Brasil. Se você estiver viajando ou quiser conhecer outras comunidades, aqui vai uma lista com alguns grupos ativos.
+    </p>
+
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do Brasil</h2>
+        <ul>
+            <li><a href="https://bhbitdevs.org/" target="_blank" rel="noopener nofollow">Belo Horizonte</a></li>
+            <li><a href="https://bitdevs.bsb.br/" target="_blank" rel="noopener nofollow">Brasília</a></li>
+            <li><a href="https://curitibabitdevs.org/" target="_blank" rel="noopener nofollow">Curitiba</a></li>
+            <li><a href="https://floripabitdevs.org/" target="_blank" rel="noopener nofollow">Florianópolis</a></li>
+            <li><a href="https://saopaulobitdevs.org/" target="_blank" rel="noopener nofollow">São Paulo</a></li>
+        </ul>
+    </div>
+
+    <div class="Home-posts">
+        <h2 class="Home-posts-title">BitDevs em outras cidades do mundo</h2>
+        <p>
+            <a href="https://bitdevs.org/cities" target="_blank" rel="noopener nofollow">
+                Ver a lista global mantida pelo BitDevs NYC
+            </a>
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
## Resumo
- adiciona a aba `Outras Cidades` no menu principal
- cria/atualiza a página `/cities` com links para os outros BitDevs do Brasil
- mantém um link separado para a lista global do BitDevs NYC

## Validação
- `git diff --check`

Closes #15
