### PR TITLE
Corrige a data do BitDevs #16

### DIFF
--- a/_posts/2026-07-08-socratic-seminar-016.md
+++ b/_posts/2026-07-08-socratic-seminar-016.md
@@ -2,7 +2,7 @@
 layout: post
 type: socratic
 title: "Seminário Socrático 016"
-meetup: https://www.meetup.com/pt-br/porto-alegre-bitdevs/events/314289352/
+meetup: https://www.meetup.com/pt-br/porto-alegre-bitdevs/events/315477760/
 ---
 
 ## Avisos


### PR DESCRIPTION
1. Corrige o link para o evento 16 no Meetup.com.
2. Corrige a data do evento na URL do post.
3. Corrige a data do evento no texto do post.
4. Corrige o título do post.